### PR TITLE
Feature/#4 Add code of infrastructure with terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,36 @@ deploy.sh
 
 # Deployment useless files
 .awspublish-tetsuzawa.com
+### https://raw.github.com/github/gitignore/55df35ee63aef4a6f859559af980c9fb87bee1a1/Terraform.gitignore
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+

--- a/deployments/infrastructure/_providers.tf
+++ b/deployments/infrastructure/_providers.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region = "ap-northeast-1"
+  version = "~> 2.49"
+}
+
+provider "aws" {
+  region = "us-east-1"
+  version = "~> 2.49"
+  alias = "us-east-1"
+}

--- a/deployments/infrastructure/_providers.tf
+++ b/deployments/infrastructure/_providers.tf
@@ -1,10 +1,10 @@
 provider "aws" {
-  region = "ap-northeast-1"
+  region  = "ap-northeast-1"
   version = "~> 2.49"
 }
 
 provider "aws" {
-  region = "us-east-1"
+  region  = "us-east-1"
   version = "~> 2.49"
-  alias = "us-east-1"
+  alias   = "us-east-1"
 }

--- a/deployments/infrastructure/main.tf
+++ b/deployments/infrastructure/main.tf
@@ -5,17 +5,17 @@ resource "aws_route53_zone" "site_zone" {
 
 locals {
   main_domain_name = "tetsuzawa.com"
-  sub_domain_name = "introduction"
-  bucket_name = "introduction.tetsuzawa.com"
+  sub_domain_name  = "introduction"
+  bucket_name      = "introduction.tetsuzawa.com"
   //  acm_arn_main = "tetsuzawa.com"
 }
 
 module "acm" {
   //  source = "github.com/tetsuzawa/terraform-environments//modules/aws/acm"
-  source = "./modules/aws/acm"
+  source           = "./modules/aws/acm"
   main_domain_name = local.main_domain_name
-  zone_id = aws_route53_zone.site_zone.zone_id
-//  acm_certificate_arn = module.acm.certificate_arn
+  zone_id          = aws_route53_zone.site_zone.zone_id
+  //  acm_certificate_arn = module.acm.certificate_arn
   providers = {
     aws = aws.us-east-1
   }
@@ -23,10 +23,10 @@ module "acm" {
 
 module "cloudfront" {
   //  source = "github.com/tetsuzawa/terraform-environments//modules/aws/static_site"
-  source = "./modules/aws/cloudfront"
-  bucket_name = local.bucket_name
-  main_domain_name = local.main_domain_name
-  sub_domain_name = local.sub_domain_name
+  source                      = "./modules/aws/cloudfront"
+  bucket_name                 = local.bucket_name
+  main_domain_name            = local.main_domain_name
+  sub_domain_name             = local.sub_domain_name
   bucket_regional_domain_name = module.static_site.bucket_regional_domain_name
   //  acm_certificate_arn = {
   //    "main_arn" : local.acm_arn_main
@@ -39,14 +39,14 @@ module "cloudfront" {
 
 module "static_site" {
   //  source = "github.com/tetsuzawa/terraform-environments//modules/aws/static_site"
-  source = "./modules/aws/static_site"
-  bucket_name = local.bucket_name
-  sub_domain_name = local.sub_domain_name
-  zone_id = aws_route53_zone.site_zone.zone_id
-  cloudfront_domain_name = module.cloudfront.domain_name
-  cloudfront_iam_arn = module.cloudfront.iam_arn
+  source                    = "./modules/aws/static_site"
+  bucket_name               = local.bucket_name
+  sub_domain_name           = local.sub_domain_name
+  zone_id                   = aws_route53_zone.site_zone.zone_id
+  cloudfront_domain_name    = module.cloudfront.domain_name
+  cloudfront_iam_arn        = module.cloudfront.iam_arn
   cloudfront_hosted_zone_id = module.cloudfront.hosted_zone_id
-  acm_certificate_arn = module.acm.certificate_arn
+  acm_certificate_arn       = module.acm.certificate_arn
   //  acm_certificate_arn = {
   //    "main" : local.acm_arn_main
   //  }

--- a/deployments/infrastructure/main.tf
+++ b/deployments/infrastructure/main.tf
@@ -1,36 +1,28 @@
 resource "aws_route53_zone" "site_zone" {
   name = "tetsuzawa.com"
-  //  zone_id = "Z2SIBCE4M149AH"
 }
 
 locals {
   main_domain_name = "tetsuzawa.com"
   sub_domain_name  = "introduction"
   bucket_name      = "introduction.tetsuzawa.com"
-  //  acm_arn_main = "tetsuzawa.com"
 }
 
 module "acm" {
-  //  source = "github.com/tetsuzawa/terraform-environments//modules/aws/acm"
   source           = "./modules/aws/acm"
   main_domain_name = local.main_domain_name
   zone_id          = aws_route53_zone.site_zone.zone_id
-  //  acm_certificate_arn = module.acm.certificate_arn
   providers = {
     aws = aws.us-east-1
   }
 }
 
 module "cloudfront" {
-  //  source = "github.com/tetsuzawa/terraform-environments//modules/aws/static_site"
   source                      = "./modules/aws/cloudfront"
   bucket_name                 = local.bucket_name
   main_domain_name            = local.main_domain_name
   sub_domain_name             = local.sub_domain_name
   bucket_regional_domain_name = module.static_site.bucket_regional_domain_name
-  //  acm_certificate_arn = {
-  //    "main_arn" : local.acm_arn_main
-  //  }
   acm_certificate_arn = module.acm.certificate_arn
   providers = {
     aws = aws.us-east-1
@@ -38,7 +30,6 @@ module "cloudfront" {
 }
 
 module "static_site" {
-  //  source = "github.com/tetsuzawa/terraform-environments//modules/aws/static_site"
   source                    = "./modules/aws/static_site"
   bucket_name               = local.bucket_name
   sub_domain_name           = local.sub_domain_name
@@ -47,9 +38,6 @@ module "static_site" {
   cloudfront_iam_arn        = module.cloudfront.iam_arn
   cloudfront_hosted_zone_id = module.cloudfront.hosted_zone_id
   acm_certificate_arn       = module.acm.certificate_arn
-  //  acm_certificate_arn = {
-  //    "main" : local.acm_arn_main
-  //  }
   iam = {
     "default.name" : "poweruser"
   }
@@ -58,18 +46,3 @@ module "static_site" {
   }
 }
 
-//module "static_site_foo" {
-//  source  = "github.com/lucheholdings/terrafrom_static_site//modules/static_site"
-//  bucket_name = "site-foo.example.com"
-//  domain = "foo.example.com"
-//  zone_id = "${aws_route53_zone.site_zone.zone_id}"
-//  acm_certificate_arn = "${module.acm.certificate_arn}"
-//}
-//
-//module "static_site_bar" {
-//  source  = "github.com/lucheholdings/terrafrom_static_site//modules/static_site"
-//  bucket_name = "site-bar.example.com"
-//  domain = "bar.example.com"
-//  zone_id = "${aws_route53_zone.site_zone.zone_id}"
-//  acm_certificate_arn = "${module.acm.certificate_arn}"
-//}

--- a/deployments/infrastructure/main.tf
+++ b/deployments/infrastructure/main.tf
@@ -1,19 +1,21 @@
 resource "aws_route53_zone" "site_zone" {
   name = "tetsuzawa.com"
-//  zone_id = "Z2SIBCE4M149AH"
+  //  zone_id = "Z2SIBCE4M149AH"
 }
 
 locals {
   main_domain_name = "tetsuzawa.com"
   sub_domain_name = "introduction"
   bucket_name = "introduction.tetsuzawa.com"
-  acm_arn_main = "tetsuzawa.com"
+  //  acm_arn_main = "tetsuzawa.com"
 }
 
 module "acm" {
   //  source = "github.com/tetsuzawa/terraform-environments//modules/aws/acm"
   source = "./modules/aws/acm"
   main_domain_name = local.main_domain_name
+  zone_id = aws_route53_zone.site_zone.zone_id
+//  acm_certificate_arn = module.acm.certificate_arn
   providers = {
     aws = aws.us-east-1
   }
@@ -26,9 +28,10 @@ module "cloudfront" {
   main_domain_name = local.main_domain_name
   sub_domain_name = local.sub_domain_name
   bucket_regional_domain_name = module.static_site.bucket_regional_domain_name
-  acm_certificate_arn = {
-    "main_arn" : local.acm_arn_main
-  }
+  //  acm_certificate_arn = {
+  //    "main_arn" : local.acm_arn_main
+  //  }
+  acm_certificate_arn = module.acm.certificate_arn
   providers = {
     aws = aws.us-east-1
   }
@@ -42,9 +45,10 @@ module "static_site" {
   cloudfront_domain_name = module.cloudfront.domain_name
   cloudfront_iam_arn = module.cloudfront.iam_arn
   cloudfront_hosted_zone_id = module.cloudfront.hosted_zone_id
-  acm_certificate_arn = {
-    "main" : local.acm_arn_main
-  }
+  acm_certificate_arn = module.acm.certificate_arn
+  //  acm_certificate_arn = {
+  //    "main" : local.acm_arn_main
+  //  }
   iam = {
     "default.name" : "poweruser"
   }

--- a/deployments/infrastructure/main.tf
+++ b/deployments/infrastructure/main.tf
@@ -1,34 +1,55 @@
 resource "aws_route53_zone" "site_zone" {
   name = "tetsuzawa.com"
+//  zone_id = "Z2SIBCE4M149AH"
+}
+
+locals {
+  main_domain_name = "tetsuzawa.com"
+  sub_domain_name = "introduction"
+  bucket_name = "introduction.tetsuzawa.com"
+  acm_arn_main = "tetsuzawa.com"
 }
 
 module "acm" {
-//  source = "github.com/tetsuzawa/terraform-environments//modules/aws/acm"
-  source = ".terraform/modules/acm/modules/aws/acm"
-  main_domain_name = "tetsuzawa.com"
-  //  zone_id = aws_route53_zone.site_zone.zone_id
+  //  source = "github.com/tetsuzawa/terraform-environments//modules/aws/acm"
+  source = "./modules/aws/acm"
+  main_domain_name = local.main_domain_name
+  providers = {
+    aws = aws.us-east-1
+  }
+}
+
+module "cloudfront" {
+  //  source = "github.com/tetsuzawa/terraform-environments//modules/aws/static_site"
+  source = "./modules/aws/cloudfront"
+  bucket_name = local.bucket_name
+  main_domain_name = local.main_domain_name
+  sub_domain_name = local.sub_domain_name
+  bucket_regional_domain_name = module.static_site.bucket_regional_domain_name
+  acm_certificate_arn = {
+    "main_arn" : local.acm_arn_main
+  }
   providers = {
     aws = aws.us-east-1
   }
 }
 
 module "static_site" {
-//  source = "github.com/tetsuzawa/terraform-environments//modules/aws/static_site"
-  source = ".terraform/modules/acm/modules/aws/static_site"
-  bucket_name = "tetsuzawa.com"
-  main_domain_name = "tetsuzawa.com"
-  sub_domain_name = {
-    "default.name" : ""
-  }
+  //  source = "github.com/tetsuzawa/terraform-environments//modules/aws/static_site"
+  source = "./modules/aws/static_site"
+  sub_domain_name = local.sub_domain_name
   zone_id = aws_route53_zone.site_zone.zone_id
+  cloudfront_domain_name = module.cloudfront.domain_name
+  cloudfront_iam_arn = module.cloudfront.iam_arn
+  cloudfront_hosted_zone_id = module.cloudfront.hosted_zone_id
   acm_certificate_arn = {
-    "main": "tetsuzawa.com"
+    "main" : local.acm_arn_main
   }
   iam = {
     "default.name" : "poweruser"
   }
   providers = {
-    aws = aws.us-east-1
+    aws = aws
   }
 }
 

--- a/deployments/infrastructure/main.tf
+++ b/deployments/infrastructure/main.tf
@@ -1,0 +1,49 @@
+resource "aws_route53_zone" "site_zone" {
+  name = "tetsuzawa.com"
+}
+
+module "acm" {
+//  source = "github.com/tetsuzawa/terraform-environments//modules/aws/acm"
+  source = ".terraform/modules/acm/modules/aws/acm"
+  main_domain_name = "tetsuzawa.com"
+  //  zone_id = aws_route53_zone.site_zone.zone_id
+  providers = {
+    aws = aws.us-east-1
+  }
+}
+
+module "static_site" {
+//  source = "github.com/tetsuzawa/terraform-environments//modules/aws/static_site"
+  source = ".terraform/modules/acm/modules/aws/static_site"
+  bucket_name = "tetsuzawa.com"
+  main_domain_name = "tetsuzawa.com"
+  sub_domain_name = {
+    "default.name" : ""
+  }
+  zone_id = aws_route53_zone.site_zone.zone_id
+  acm_certificate_arn = {
+    "main": "tetsuzawa.com"
+  }
+  iam = {
+    "default.name" : "poweruser"
+  }
+  providers = {
+    aws = aws.us-east-1
+  }
+}
+
+//module "static_site_foo" {
+//  source  = "github.com/lucheholdings/terrafrom_static_site//modules/static_site"
+//  bucket_name = "site-foo.example.com"
+//  domain = "foo.example.com"
+//  zone_id = "${aws_route53_zone.site_zone.zone_id}"
+//  acm_certificate_arn = "${module.acm.certificate_arn}"
+//}
+//
+//module "static_site_bar" {
+//  source  = "github.com/lucheholdings/terrafrom_static_site//modules/static_site"
+//  bucket_name = "site-bar.example.com"
+//  domain = "bar.example.com"
+//  zone_id = "${aws_route53_zone.site_zone.zone_id}"
+//  acm_certificate_arn = "${module.acm.certificate_arn}"
+//}

--- a/deployments/infrastructure/main.tf
+++ b/deployments/infrastructure/main.tf
@@ -40,6 +40,7 @@ module "cloudfront" {
 module "static_site" {
   //  source = "github.com/tetsuzawa/terraform-environments//modules/aws/static_site"
   source = "./modules/aws/static_site"
+  bucket_name = local.bucket_name
   sub_domain_name = local.sub_domain_name
   zone_id = aws_route53_zone.site_zone.zone_id
   cloudfront_domain_name = module.cloudfront.domain_name

--- a/deployments/infrastructure/modules/aws/acm/acm.tf
+++ b/deployments/infrastructure/modules/aws/acm/acm.tf
@@ -1,0 +1,3 @@
+data "aws_acm_certificate" "main" {
+  domain = "*.${var.main_domain_name}"
+}

--- a/deployments/infrastructure/modules/aws/acm/acm.tf
+++ b/deployments/infrastructure/modules/aws/acm/acm.tf
@@ -1,3 +1,24 @@
-data "aws_acm_certificate" "main" {
-  domain = "*.${var.main_domain_name}"
+//data "aws_acm_certificate" "main" {
+//  domain = "*.${var.main_domain_name}"
+//}
+
+resource "aws_acm_certificate" "cert" {
+  domain_name = var.main_domain_name
+  subject_alternative_names = ["*.${var.main_domain_name}"]
+  validation_method = "DNS"
+}
+
+resource "aws_route53_record" "cert" {
+  # Count=2, because we need to valdiate both "example.com" and "*.example.com".
+  count = 1
+  name = aws_acm_certificate.cert.domain_validation_options[count.index]["resource_record_name"]
+  type = aws_acm_certificate.cert.domain_validation_options[count.index]["resource_record_type"]
+  zone_id = var.zone_id
+  records = [aws_acm_certificate.cert.domain_validation_options[count.index]["resource_record_value"]]
+  ttl = 300
+}
+
+resource "aws_acm_certificate_validation" "acm_cert" {
+  certificate_arn = aws_acm_certificate.cert.arn
+  validation_record_fqdns = aws_route53_record.cert.*.fqdn
 }

--- a/deployments/infrastructure/modules/aws/acm/output.tf
+++ b/deployments/infrastructure/modules/aws/acm/output.tf
@@ -1,0 +1,5 @@
+output "acm" {
+  value = {
+    "main_arn" = data.aws_acm_certificate.main.arn
+  }
+}

--- a/deployments/infrastructure/modules/aws/acm/output.tf
+++ b/deployments/infrastructure/modules/aws/acm/output.tf
@@ -1,5 +1,12 @@
-output "acm" {
+//output "acm" {
+//  value = {
+//    "main_arn" = data.aws_acm_certificate.main.arn
+//  }
+//}
+output "certificate_arn" {
+  description = "Arn of validated certificate arn"
+  //  value = aws_acm_certificate_validation.acm_cert.certificate_arn
   value = {
-    "main_arn" = data.aws_acm_certificate.main.arn
+    "main_arn" = aws_acm_certificate_validation.acm_cert.certificate_arn
   }
 }

--- a/deployments/infrastructure/modules/aws/acm/variables.tf
+++ b/deployments/infrastructure/modules/aws/acm/variables.tf
@@ -1,0 +1,4 @@
+variable "main_domain_name" {
+  type = string
+  default = ""
+}

--- a/deployments/infrastructure/modules/aws/acm/variables.tf
+++ b/deployments/infrastructure/modules/aws/acm/variables.tf
@@ -1,4 +1,11 @@
 variable "main_domain_name" {
   type = string
   default = ""
+  description = "The Domain of the application. (e.g. `example.com`)"
+}
+
+variable "zone_id" {
+  type = string
+  default = ""
+  description = "ID of hosted zone."
 }

--- a/deployments/infrastructure/modules/aws/acm/versions.tf
+++ b/deployments/infrastructure/modules/aws/acm/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/deployments/infrastructure/modules/aws/cloudfront/cloudfront.tf
+++ b/deployments/infrastructure/modules/aws/cloudfront/cloudfront.tf
@@ -1,0 +1,76 @@
+resource "aws_cloudfront_distribution" "static_site" {
+
+  aliases = [
+    var.sub_domain_name == "" ? var.main_domain_name : "${var.sub_domain_name}.${var.main_domain_name}"]
+
+  origin {
+    domain_name = var.bucket_regional_domain_name
+    origin_id = "S3-${var.bucket_name}"
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.static_site_origin_access_identity.cloudfront_access_identity_path
+    }
+  }
+
+  enabled = true
+  is_ipv6_enabled = true
+  default_root_object = "index.html"
+
+  default_cache_behavior {
+    allowed_methods = [
+      "GET",
+      "HEAD",]
+    cached_methods = [
+      "GET",
+      "HEAD"]
+    compress = false
+    target_origin_id = "S3-${var.bucket_name}"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl = 0
+    default_ttl = 3600
+    max_ttl = 86400
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  price_class = "PriceClass_200"
+
+  custom_error_response {
+    error_caching_min_ttl = 300
+    error_code = 403
+    response_code = 200
+    response_page_path = "/index.html"
+  }
+
+  custom_error_response {
+    error_caching_min_ttl = 300
+    error_code = 404
+    response_code = 404
+    response_page_path = "/index.html"
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = false
+    acm_certificate_arn = var.acm_certificate_arn["main_arn"]
+    ssl_support_method = "sni-only"
+    minimum_protocol_version = "TLSv1"
+  }
+}
+
+resource "aws_cloudfront_origin_access_identity" "static_site_origin_access_identity" {
+  comment = "access-identity-S3-${var.bucket_name}"
+}
+

--- a/deployments/infrastructure/modules/aws/cloudfront/output.tf
+++ b/deployments/infrastructure/modules/aws/cloudfront/output.tf
@@ -1,0 +1,11 @@
+output "domain_name" {
+  value = aws_cloudfront_distribution.static_site.domain_name
+}
+
+output "hosted_zone_id" {
+  value = aws_cloudfront_distribution.static_site.hosted_zone_id
+}
+
+output "iam_arn" {
+  value = aws_cloudfront_origin_access_identity.static_site_origin_access_identity.iam_arn
+}

--- a/deployments/infrastructure/modules/aws/cloudfront/variables.tf
+++ b/deployments/infrastructure/modules/aws/cloudfront/variables.tf
@@ -1,0 +1,32 @@
+variable "bucket_name" {
+  type = string
+  default = "static-site"
+}
+
+variable "main_domain_name" {
+  type = string
+  default = ""
+  description = "The Domain which you want to serve the website on (e.g. `example.com`)"
+}
+
+variable "sub_domain_name" {
+  type = string
+  default = ""
+  description = "The Sub Domain which you want to serve the website on (e.g. `test`)"
+}
+
+variable "acm_certificate_arn" {
+  type = map(string)
+  default = {}
+  description = "The Domain of site (e.g. `example.com`)"
+}
+
+variable "cloudfront_region" {
+  type = string
+  default = "us-east-1"
+}
+
+variable "bucket_regional_domain_name" {
+  type = string
+  default = ""
+}

--- a/deployments/infrastructure/modules/aws/static_site/output.tf
+++ b/deployments/infrastructure/modules/aws/static_site/output.tf
@@ -1,0 +1,3 @@
+output "bucket_regional_domain_name" {
+  value = aws_s3_bucket.static_site.bucket_regional_domain_name
+}

--- a/deployments/infrastructure/modules/aws/static_site/route53.tf
+++ b/deployments/infrastructure/modules/aws/static_site/route53.tf
@@ -1,0 +1,16 @@
+//data "aws_route53_zone" "web" {
+//  name = var.main_domain_name
+//}
+
+resource "aws_route53_record" "static_site" {
+//  zone_id = data.aws_route53_zone.web.zone_id
+  zone_id = var.zone_id
+  name = var.sub_domain_name == "" ? var.main_domain_name : "${var.sub_domain_name}.${var.main_domain_name}"
+  type = "A"
+
+  alias {
+    name = var.cloudfront_domain_name
+    zone_id = var.cloudfront_hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/deployments/infrastructure/modules/aws/static_site/s3.tf
+++ b/deployments/infrastructure/modules/aws/static_site/s3.tf
@@ -9,10 +9,6 @@ resource "aws_s3_bucket" "static_site" {
   }
 }
 
-//resource "aws_s3_bucket" "static_site_access_logs" {
-//  bucket        = "logs${var.bucket_name}"
-//  force_destroy = true
-//}
 
 data "aws_iam_policy_document" "static_site_s3_policy" {
   statement {
@@ -23,7 +19,8 @@ data "aws_iam_policy_document" "static_site_s3_policy" {
 
     principals {
       type = "AWS"
-      identifiers = [var.cloudfront_iam_arn]
+      identifiers = [
+        var.cloudfront_iam_arn]
     }
   }
 }
@@ -36,25 +33,9 @@ resource "aws_s3_bucket_policy" "static_site" {
 resource "aws_s3_bucket_public_access_block" "static_site" {
   bucket = aws_s3_bucket.static_site.id
 
-  block_public_acls   = true
+  block_public_acls = true
   block_public_policy = true
   ignore_public_acls = true
   restrict_public_buckets = true
 }
 
-//data "aws_iam_policy_document" "static_site_access_logs" {
-//  statement {
-//    actions   = ["s3:PutObject"]
-//    resources = ["${aws_s3_bucket.static_site_access_logs.arn}/*"]
-//
-//    principals {
-//      type        = "AWS"
-//      identifiers = [var.cloudfront_iam_arn]
-//    }
-//  }
-//}
-//
-//resource "aws_s3_bucket_policy" "static_site_access_logs" {
-//  bucket = aws_s3_bucket.static_site_access_logs.id
-//  policy = data.aws_iam_policy_document.static_site_access_logs.json
-//}

--- a/deployments/infrastructure/modules/aws/static_site/s3.tf
+++ b/deployments/infrastructure/modules/aws/static_site/s3.tf
@@ -1,6 +1,12 @@
 resource "aws_s3_bucket" "static_site" {
-  bucket        = var.bucket_name
+  bucket = var.bucket_name
   force_destroy = true
+  acl = "private"
+
+  website {
+    index_document = "index.html"
+    error_document = "index.html"
+  }
 }
 
 //resource "aws_s3_bucket" "static_site_access_logs" {
@@ -10,12 +16,15 @@ resource "aws_s3_bucket" "static_site" {
 
 data "aws_iam_policy_document" "static_site_s3_policy" {
   statement {
-    actions   = ["s3:GetObject"]
-    resources = ["${aws_s3_bucket.static_site.arn}/*"]
+    actions = [
+      "s3:GetObject"]
+    resources = [
+      "${aws_s3_bucket.static_site.arn}/*"]
 
     principals {
-      type        = "AWS"
-      identifiers = [var.cloudfront_iam_arn]
+      type = "AWS"
+      identifiers = [
+        var.cloudfront_iam_arn]
     }
   }
 }
@@ -23,6 +32,15 @@ data "aws_iam_policy_document" "static_site_s3_policy" {
 resource "aws_s3_bucket_policy" "static_site" {
   bucket = aws_s3_bucket.static_site.id
   policy = data.aws_iam_policy_document.static_site_s3_policy.json
+}
+
+resource "aws_s3_bucket_public_access_block" "static_site" {
+  bucket = aws_s3_bucket.static_site.id
+
+  block_public_acls   = true
+  block_public_policy = true
+  ignore_public_acls = true
+  restrict_public_buckets = true
 }
 
 //data "aws_iam_policy_document" "static_site_access_logs" {

--- a/deployments/infrastructure/modules/aws/static_site/s3.tf
+++ b/deployments/infrastructure/modules/aws/static_site/s3.tf
@@ -3,10 +3,10 @@ resource "aws_s3_bucket" "static_site" {
   force_destroy = true
 }
 
-resource "aws_s3_bucket" "static_site_access_logs" {
-  bucket        = "${var.bucket_name}-logs"
-  force_destroy = true
-}
+//resource "aws_s3_bucket" "static_site_access_logs" {
+//  bucket        = "logs${var.bucket_name}"
+//  force_destroy = true
+//}
 
 data "aws_iam_policy_document" "static_site_s3_policy" {
   statement {
@@ -25,19 +25,19 @@ resource "aws_s3_bucket_policy" "static_site" {
   policy = data.aws_iam_policy_document.static_site_s3_policy.json
 }
 
-data "aws_iam_policy_document" "static_site_access_logs" {
-  statement {
-    actions   = ["s3:PutObject"]
-    resources = ["${aws_s3_bucket.static_site_access_logs.arn}/*"]
-
-    principals {
-      type        = "AWS"
-      identifiers = [var.cloudfront_iam_arn]
-    }
-  }
-}
-
-resource "aws_s3_bucket_policy" "static_site_access_logs" {
-  bucket = aws_s3_bucket.static_site_access_logs.id
-  policy = data.aws_iam_policy_document.static_site_access_logs.json
-}
+//data "aws_iam_policy_document" "static_site_access_logs" {
+//  statement {
+//    actions   = ["s3:PutObject"]
+//    resources = ["${aws_s3_bucket.static_site_access_logs.arn}/*"]
+//
+//    principals {
+//      type        = "AWS"
+//      identifiers = [var.cloudfront_iam_arn]
+//    }
+//  }
+//}
+//
+//resource "aws_s3_bucket_policy" "static_site_access_logs" {
+//  bucket = aws_s3_bucket.static_site_access_logs.id
+//  policy = data.aws_iam_policy_document.static_site_access_logs.json
+//}

--- a/deployments/infrastructure/modules/aws/static_site/s3.tf
+++ b/deployments/infrastructure/modules/aws/static_site/s3.tf
@@ -23,8 +23,7 @@ data "aws_iam_policy_document" "static_site_s3_policy" {
 
     principals {
       type = "AWS"
-      identifiers = [
-        var.cloudfront_iam_arn]
+      identifiers = [var.cloudfront_iam_arn]
     }
   }
 }

--- a/deployments/infrastructure/modules/aws/static_site/s3.tf
+++ b/deployments/infrastructure/modules/aws/static_site/s3.tf
@@ -1,0 +1,43 @@
+resource "aws_s3_bucket" "static_site" {
+  bucket        = var.bucket_name
+  force_destroy = true
+}
+
+resource "aws_s3_bucket" "static_site_access_logs" {
+  bucket        = "${var.bucket_name}-logs"
+  force_destroy = true
+}
+
+data "aws_iam_policy_document" "static_site_s3_policy" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.static_site.arn}/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [var.cloudfront_iam_arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "static_site" {
+  bucket = aws_s3_bucket.static_site.id
+  policy = data.aws_iam_policy_document.static_site_s3_policy.json
+}
+
+data "aws_iam_policy_document" "static_site_access_logs" {
+  statement {
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.static_site_access_logs.arn}/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [var.cloudfront_iam_arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "static_site_access_logs" {
+  bucket = aws_s3_bucket.static_site_access_logs.id
+  policy = data.aws_iam_policy_document.static_site_access_logs.json
+}

--- a/deployments/infrastructure/modules/aws/static_site/variables.tf
+++ b/deployments/infrastructure/modules/aws/static_site/variables.tf
@@ -1,0 +1,52 @@
+variable "bucket_name" {
+  type = string
+  default = ""
+}
+
+variable "main_domain_name" {
+  type = string
+  default = ""
+  description = "The Domain which you want to serve the website on (e.g. `example.com`)"
+}
+
+variable "sub_domain_name" {
+  type = string
+  default = ""
+  description = "The Sub Domain which you want to serve the website on (e.g. `test`)"
+}
+
+
+variable "zone_id" {
+  description = "The ID of hosted zone which your domain will be hosted"
+}
+
+variable "acm_certificate_arn" {
+  type = map(string)
+  default = {}
+  description = "The Domain of site (e.g. `example.com`)"
+}
+
+variable "iam" {
+  type = map(string)
+  default = {}
+}
+
+variable "cloudfront_iam_arn" {
+  type = string
+  default = ""
+}
+
+variable "cloudfront_domain_name" {
+  type = string
+  default = ""
+}
+
+variable "cloudfront_hosted_zone_id" {
+  type = string
+  default = ""
+}
+
+variable "cloudfront_region" {
+  type = string
+  default = "us-east-1"
+}

--- a/deployments/infrastructure/output.tf
+++ b/deployments/infrastructure/output.tf
@@ -1,0 +1,3 @@
+output "name_servers" {
+  value = aws_route53_zone.site_zone.name_servers
+}


### PR DESCRIPTION
terraformを使ってAWSの既存の環境と同等のインフラを用意できるようにした。
ただしdomainは重複できないので、introduction.tetsuzawa.comに設定してある。